### PR TITLE
Update uncertainty text in analysis outputs

### DIFF
--- a/app2.py
+++ b/app2.py
@@ -231,6 +231,10 @@ def display_statistical_analysis(original_pil, results):
 
 def display_final_report(results):
     st.header("Tahap 4: Laporan Akhir dan Interpretasi")
+    st.markdown(
+        "Bagian ini merangkum temuan utama beserta skor kepercayaan dan tingkat ketidakpastian. "
+        "Harap telaah indikator keandalan sebelum mengambil keputusan akhir."
+    )
 
     # ... (Panel penjelasan tetap sama) ...
 
@@ -257,9 +261,9 @@ def display_final_report(results):
                 else:
                     st.success(f"**Indikasi Utama:** {primary_assessment}", icon="✅")
 
-                # Hanya tampilkan tingkat keyakinan jika ketidakpastian RENDAH (< 25%)
+                # Hanya tampilkan skor kepercayaan jika ketidakpastian RENDAH (< 25%)
                 if uncertainty_level < 0.25:
-                    st.metric(label="Tingkat Keyakinan", value=confidence_level)
+                    st.metric(label="Skor Kepercayaan", value=confidence_level)
                 else:
                     # Jika tidak pasti, tampilkan level ketidakpastian sebagai gantinya
                     st.metric(label="Tingkat Ketidakpastian", value=f"{uncertainty_level*100:.1f}%", delta="Hasil Ambigu", delta_color="inverse")
@@ -275,8 +279,8 @@ def display_final_report(results):
             # ... (Sisa kode untuk menampilkan grafik bar probabilitas, dll. tetap sama) ...
             
             # PENINGKATAN #4: Beri penekanan pada penjelasan teknis ketidakpastian
-            with st.expander("🔍 Alasan di Balik Hasil Analisis (Detail Teknis)", expanded=True):
-                st.markdown(f"**Deskripsi Ketidakpastian:** {report_details.get('uncertainty_description', 'N/A')}")
+            with st.expander("🔍 Penjelasan Detail Ketidakpastian", expanded=True):
+                st.markdown(f"**Rangkuman Ketidakpastian:** {report_details.get('uncertainty_summary', 'N/A')}")
                 st.markdown("**Indikator Keandalan:**")
                 for indicator in report_details.get('reliability_indicators', []):
                     st.markdown(f"- {indicator}")
@@ -1054,7 +1058,7 @@ def main_app():
             "📊 Tahap 1: Analisis Inti",
             "🔬 Tahap 2: Analisis Lanjut",
             "📈 Tahap 3: Analisis Statistik",
-            "📋 Tahap 4: Laporan Akhir & Probabilitas", # Nama tab bisa diubah
+            "📋 Tahap 4: Laporan Akhir & Kepercayaan", # Nama tab bisa diubah
             "🧪 Tahap 5: Hasil Pengujian", # Updated tab name
             "📄 Ekspor Laporan",
             "📜 Riwayat Analisis"

--- a/classification.py
+++ b/classification.py
@@ -537,7 +537,7 @@ def classify_manipulation_advanced(analysis_results):
         final_manipulation_type = uncertainty_report.get('primary_assessment', 'N/A').replace('Indikasi: ', '')
         final_confidence = uncertainty_report.get('confidence_level', 'Sangat Rendah')
         final_details = uncertainty_report.get('reliability_indicators', [])
-        final_details.append(uncertainty_report.get('uncertainty_description', ''))
+        final_details.append(uncertainty_report.get('uncertainty_summary', ''))
 
         classification_result = {
             'type': final_manipulation_type,
@@ -571,7 +571,7 @@ def classify_manipulation_advanced(analysis_results):
             'ml_scores': {}, 'feature_vector': [], 'traditional_scores': {},
             'uncertainty_analysis': {
                 'probabilities': {'copy_move_probability': 0.0, 'splicing_probability': 0.0, 'authentic_probability': 1.0, 'uncertainty_level': 1.0, 'confidence_intervals': {'copy_move': {'lower':0, 'upper':0}, 'splicing': {'lower':0, 'upper':0}, 'authentic': {'lower':0, 'upper':0}}},
-                'report': {'primary_assessment': 'Error: Data Insufficient', 'confidence_level': 'Sangat Rendah', 'uncertainty_description': 'Major data issues, classification unreliable', 'reliability_indicators': [], 'recommendation': 'Rerun analysis with valid data or debug.'},
+                'report': {'primary_assessment': 'Error: Data Insufficient', 'confidence_level': 'Sangat Rendah', 'uncertainty_summary': 'Major data issues, classification unreliable', 'reliability_indicators': [], 'recommendation': 'Rerun analysis with valid data or debug.'},
                 'formatted_output': "Error: Classification data missing. See logs."
             }
         }
@@ -585,7 +585,7 @@ def classify_manipulation_advanced(analysis_results):
             'ml_scores': {}, 'feature_vector': [], 'traditional_scores': {},
             'uncertainty_analysis': {
                 'probabilities': {'copy_move_probability': 0.0, 'splicing_probability': 0.0, 'authentic_probability': 1.0, 'uncertainty_level': 1.0, 'confidence_intervals': {'copy_move': {'lower':0, 'upper':0}, 'splicing': {'lower':0, 'upper':0}, 'authentic': {'lower':0, 'upper':0}}},
-                'report': {'primary_assessment': 'Error: Unknown Issue', 'confidence_level': 'Sangat Rendah', 'uncertainty_description': 'An unexpected error occurred during classification. Result is unreliable.', 'reliability_indicators': [], 'recommendation': 'Rerun analysis or consult support.'},
+                'report': {'primary_assessment': 'Error: Unknown Issue', 'confidence_level': 'Sangat Rendah', 'uncertainty_summary': 'An unexpected error occurred during classification. Result is unreliable.', 'reliability_indicators': [], 'recommendation': 'Rerun analysis or consult support.'},
                 'formatted_output': "Error: Classification process failed. See logs for details."
             }
         }

--- a/export_utils.py
+++ b/export_utils.py
@@ -1156,7 +1156,7 @@ def add_conclusion_advanced(doc, analysis_results):
         
         doc.add_paragraph("### Hasil Klasifikasi Probabilistik:", level=3)
         doc.add_paragraph(f"• Penilaian Utama: {uncertainty_report.get('primary_assessment', 'N/A')}")
-        doc.add_paragraph(f"• Tingkat Keyakinan Sistem: {uncertainty_report.get('confidence_level', 'N/A')}")
+        doc.add_paragraph(f"• Skor Kepercayaan Sistem: {uncertainty_report.get('confidence_level', 'N/A')}")
         doc.add_paragraph(f"• Tingkat Ketidakpastian: {probabilities.get('uncertainty_level', 0):.1%}")
 
         doc.add_paragraph("\nDistribusi Probabilitas:", level=3)
@@ -1492,7 +1492,7 @@ def add_system_validation_section(doc, analysis_results=None):
     doc.add_paragraph(
         f"Berdasarkan integritas pipeline ({pipeline_integrity_score:.1f}%), validasi silang algoritma ({algo_score_display:.1f}%), "
         f"skor kepercayaan forensik keseluruhan untuk analisis ini adalah **{final_overall_score:.1f}%**. "
-        f"Skor ini merepresentasikan tingkat keyakinan terhadap kesimpulan akhir."
+        f"Skor ini merepresentasikan derajat kepercayaan terhadap kesimpulan akhir."
     )
     
     # Add confidence interpretation based on `final_overall_score`

--- a/main.py
+++ b/main.py
@@ -491,7 +491,7 @@ def analyze_image_comprehensive_advanced(image_path, output_dir="./results"):
             # Provide minimum uncertainty analysis structure if it failed
             'uncertainty_analysis': { 
                 'probabilities': {'copy_move_probability': 0.0, 'splicing_probability': 0.0, 'authentic_probability': 1.0, 'uncertainty_level': 1.0, 'confidence_intervals': {k:{'lower':0,'upper':0} for k in ['copy_move','splicing','authentic']}},
-                'report': {'primary_assessment': 'Classification Failed', 'confidence_level': 'Sangat Rendah', 'uncertainty_description': 'Internal error, result unreliable', 'reliability_indicators': [], 'recommendation': 'Rerun analysis.'},
+                'report': {'primary_assessment': 'Classification Failed', 'confidence_level': 'Sangat Rendah', 'uncertainty_summary': 'Internal error, result unreliable', 'reliability_indicators': [], 'recommendation': 'Rerun analysis.'},
                 'formatted_output': "Classification process failed."
             }
         }

--- a/uncertainty_classification.py
+++ b/uncertainty_classification.py
@@ -389,7 +389,7 @@ class UncertaintyClassifier:
         report = {
             'primary_assessment': self._determine_primary_assessment(probabilities),
             'confidence_level': self._determine_confidence_level(probabilities),
-            'uncertainty_description': self._describe_uncertainty(probabilities['uncertainty_level']),
+            'uncertainty_summary': self._summarize_uncertainty(probabilities['uncertainty_level']),
             'reliability_indicators': self._generate_reliability_indicators(probabilities),
             'recommendation': self._generate_recommendation(probabilities)
         }
@@ -479,8 +479,8 @@ class UncertaintyClassifier:
         else:
             return "Sangat Rendah"
     
-    def _describe_uncertainty(self, uncertainty_level: float) -> str:
-        """Describe uncertainty in human-readable form."""
+    def _summarize_uncertainty(self, uncertainty_level: float) -> str:
+        """Summarize uncertainty in human-readable form."""
         if uncertainty_level < 0.1:
             return "Sangat rendah: Bukti yang ditemukan sangat konsisten dan jelas."
         elif uncertainty_level < 0.2:
@@ -562,7 +562,7 @@ def format_probability_results(probabilities: Dict, details: Dict) -> str:
     
     # Primary Assessment
     output.append(f"PENILAIAN UTAMA: {details['primary_assessment']}")
-    output.append(f"TINGKAT KEYAKINAN: {details['confidence_level']}")
+    output.append(f"SKOR KEPERCAYAAN: {details['confidence_level']}")
     output.append("")
     
     # Probability Distribution
@@ -584,7 +584,7 @@ def format_probability_results(probabilities: Dict, details: Dict) -> str:
     # Uncertainty Analysis
     output.append("ANALISIS KETIDAKPASTIAN:")
     output.append(f"Tingkat ketidakpastian: {probabilities['uncertainty_level']:.1%}")
-    output.append(details['uncertainty_description'])
+    output.append(details['uncertainty_summary'])
     output.append("")
     
     # Reliability Indicators

--- a/visualization.py
+++ b/visualization.py
@@ -334,7 +334,7 @@ def create_uncertainty_visualization(ax, results):
     y_start_pos -= line_height
 
     # Detailed Uncertainty Description
-    uncertainty_desc_text = report_details.get('uncertainty_description', 'No description available.')
+    uncertainty_desc_text = report_details.get('uncertainty_summary', 'No description available.')
     # Using markdown or similar approach within text to denote importance, if not raw text
     ax.text(0.05, y_start_pos, 
             f"_{uncertainty_desc_text}_", # Italicize description


### PR DESCRIPTION
## Summary
- rename `_describe_uncertainty` to `_summarize_uncertainty`
- replace `uncertainty_description` fields with `uncertainty_summary`
- show "Skor Kepercayaan" instead of "Tingkat Keyakinan"
- add clarifying message in Stage 4 final report

## Testing
- `pip install numpy opencv-python Pillow pytest coverage radon`
- `pytest -q` *(fails: test_ela_analysis_logic, test_feature_detection_logic)*

------
https://chatgpt.com/codex/tasks/task_b_6866da045ab4832fb183f87ac7ac4c37